### PR TITLE
Add dynamic sub directory scan for project stuff with ".tmux-scan" to include sub directory and ".tmux-exclude" to ignore directory as project

### DIFF
--- a/tmux-sessionizer
+++ b/tmux-sessionizer
@@ -19,12 +19,51 @@ hydrate() {
     fi
 }
 
+readonly ROOT="~/personal/dev/env/.config "
+
+# Search Roots projects directories
+
+DIRECTORIES=("$ROOT")
+
+function search_roots_directories_scan {
+    for item in "$1"/*; do
+        if [ -d "$item" ]; then
+            if [ -f "$item/.tmux-scan" ]; then
+                DIRECTORIES+=($item)
+                
+                search_roots_directories_scan "$item"
+            fi
+        fi
+    done
+}
+
 if [[ $# -eq 1 ]]; then
     selected=$1
 else
-    # If someone wants to make this extensible, i'll accept
-    # PR
-    selected=$(find ~/personal/dev/env/.config -mindepth 1 -maxdepth 1 -type d | fzf)
+    search_roots_directories_scan "$ROOT"
+
+    exclude_folder=""
+
+    # Remove .tmux-scan directories
+    for directory in "${DIRECTORIES[@]}"; do
+        exclude_folder+="($directory$)|"
+    done
+
+    # Remove .tmux-exclude directories
+    for directory in "${DIRECTORIES[@]}"; do
+      for item in "$directory"/*; do
+          if [ -d "$item" ]; then
+              if [ -f "$item/.tmux-exclude" ]; then
+                exclude_folder+="($item$)|"
+              fi
+          fi
+      done
+    done
+
+    exclude_folder=${exclude_folder%"|"}
+
+    # Show FZF
+    selected=$(find "${DIRECTORIES[@]}" -mindepth 1 -maxdepth 1 -type d | rg -v "${exclude_folder}" | fzf)
 fi
 
 if [[ -z $selected ]]; then


### PR DESCRIPTION
This is a early hack of my personal edit of tmux-sessionizer.

I did some voodo magie with bash array a long time ago and I know it's a crime.

This implementation do a recursive search for creating a list when ".tmux-scan" is present and will ignore in the find ".tmux-exclude".

I will do a proper PR message latter since I still got works todo but since I saw you maybe wanted something like this.