### PR TITLE
Map `:` to `_` before checking whether session exists

### DIFF
--- a/tmux-sessionizer
+++ b/tmux-sessionizer
@@ -31,7 +31,7 @@ if [[ -z $selected ]]; then
     exit 0
 fi
 
-selected_name=$(basename "$selected" | tr . _)
+selected_name=$(basename "$selected" | tr .: _)
 tmux_running=$(pgrep tmux)
 
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then


### PR DESCRIPTION
The project already supports `.` properly, but not `:`, which also is mapped to `_` in tmux session names. See here: https://github.com/tmux/tmux/blob/46f384665965dd279754915772d3d86245b48784/session.c#L245-L246