### PR TITLE
Remove dependency on default list-sessions format

### DIFF
--- a/tmux-sessionizer
+++ b/tmux-sessionizer
@@ -8,7 +8,7 @@ switch_to() {
 }
 
 has_session() {
-    tmux list-sessions | grep -q "^$1:"
+    tmux list-sessions -F '#{session_name}' | grep -qx "$1"
 }
 
 hydrate() {


### PR DESCRIPTION
Currently, `has_session` depends on the default output format of `list-sessions` being what it is, ie beginning with `session_name:`. While it's not particularly likely that the default format will change, and the only practical problem with the way it is happens if the input is something like `my_session: 4 windows (created Tue Oct 22 07`[1], this seems like a _cleaner_ way of doing it (that's a joke, I watch your vids). But I understand if you would rather leave it as is.

[1] which will match if `my_session` exists, has 4 windows, and was created Tue Oct 22 between `[07:00:00, 08:00:00)`, in any year that Oct 22 is a Tuesday