### PR TITLE
Fix hydration when tmux is not running

### DIFF
--- a/tmux-sessionizer
+++ b/tmux-sessionizer
@@ -35,9 +35,8 @@ selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s $selected_name -c $selected
+    tmux new-session -ds $selected_name -c $selected
     hydrate $selected_name $selected
-    exit 0
 fi
 
 if ! has_session $selected_name; then


### PR DESCRIPTION
When tmux is off, the script [correctly creates a new session](https://github.com/ThePrimeagen/tmux-sessionizer/blob/master/tmux-sessionizer#L37-L41) but hydration fails. Subsequent navigations with tmux-sessionizer correctly executes hydration, which indicates the first condition has a bug.

### Reproduction steps:
1. Detach from `tmux`
2. Run `tmux kill-server`
3. Run `tmux-sessionizer` and select a directory with a `.tmux-sessionizer` in it

### Current behavior
A new tmux session is created successfully, but hydration fails. My guess is that hydration happens too soon and it's sent to the previous running environment outside of tmux.

_**Note**: I'm unsure if this is something wrong on my setup. [Here's my tmux config](https://github.com/gonstoll/dotfiles/blob/master/.config/tmux/tmux.conf) just in case. Apologies in advance if this is something wrong on my end._

### Expected behavior
A new tmux session is created successfully, and hydration is executed successfully.

### Proposed solution
Based on my theory aforementioned: start a detached session, send keys to it and then attach to it. This ensures attaching to the session happens after the session.