### PR TITLE
Add fzf directory config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ fzf and tmux
 tmux-sessionizer [<partial name of session>]
 ```
 
-if you execute tmux-sessionizer without any parameters it will FZF set of default directories or ones specified in config file.
+if you execute tmux-sessionizer without any parameters it will FZF set of default directories or ones specified in config file (see below).
 
 ### Example
 ```bash
-# ~/.config/tmux-sessionizer/tmux-sessionizer.conf
+# file: ~/.config/tmux-sessionizer/tmux-sessionizer.conf
 TS_SEARCH_PATHS=(~/) # set the search path to ~/
 TS_EXTRA_SEARCH_PATHS=(~/Coding:3 ~/Git:3 ~/.config:2 ~/projects:3) # set the extra search paths, with a depth (e.g. ~/Git:3)
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ tmux-sessionizer [<partial name of session>]
 
 if you execute tmux-sessionizer without any parameters it will FZF set of default directories or ones specified in config file.
 
+### Example
+```bash
+# ~/.config/tmux-sessionizer/tmux-sessionizer.conf
+TS_SEARCH_PATHS=(~/) # set the search path to ~/
+TS_EXTRA_SEARCH_PATHS=(~/Coding:3 ~/Git:3 ~/.config:2 ~/projects:3) # set the extra search paths, with a depth (e.g. ~/Git:3)
+```
+
 ## Session Commands
 Session commands are for you to write / navigate without using tmux navigation commands.
 They are meant to be used with zsh/vim/tmux remaps.


### PR DESCRIPTION
Adds an example config section to the README to show how to set TS_SEARCH_PATHS and TS_EXTRA_SEARCH_PATHS in the config file. Currently, users need to read the script comments to understand this, so this should make it clearer.